### PR TITLE
Add cpu load for Linux and Darwin

### DIFF
--- a/src/github.com/imc-trading/peekaboo/daemon/daemon_darwin.go
+++ b/src/github.com/imc-trading/peekaboo/daemon/daemon_darwin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/imc-trading/peekaboo/network/routes"
 	"github.com/imc-trading/peekaboo/system"
 	"github.com/imc-trading/peekaboo/system/cpu"
+	"github.com/imc-trading/peekaboo/system/cpu/load"
 	"github.com/imc-trading/peekaboo/system/memory"
 	"github.com/imc-trading/peekaboo/system/opsys"
 )
@@ -28,6 +29,7 @@ func New() Daemon {
 			apiURL + "/system":             {Timeout: 5 * 60}, // 5 min.
 			apiURL + "/system/os":          {Timeout: 5 * 60}, // 5 min.
 			apiURL + "/system/cpu":         {Timeout: 5 * 60}, // 5 min.
+			apiURL + "/system/cpu/load":    {Timeout: 5 * 60}, // 5 min.
 			apiURL + "/system/memory":      {Timeout: 5 * 60}, // 5 min.
 			apiURL + "/network/interfaces": {Timeout: 5 * 60}, // 5 min.
 			apiURL + "/network/routes":     {Timeout: 5 * 60}, // 5 min.
@@ -46,6 +48,7 @@ func (d *daemon) Run(bind string, static string) error {
 	d.addAPIRoute(apiURL+"/system", system.GetInterface)
 	d.addAPIRoute(apiURL+"/system/os", opsys.GetInterface)
 	d.addAPIRoute(apiURL+"/system/cpu", cpu.GetInterface)
+	d.addAPIRoute(apiURL+"/system/cpu/load", load.GetInterface)
 	d.addAPIRoute(apiURL+"/system/memory", memory.GetInterface)
 	d.addAPIRoute(apiURL+"/docker", docker.GetInterface)
 	d.addAPIRoute(apiURL+"/docker/containers", containers.GetInterface)

--- a/src/github.com/imc-trading/peekaboo/daemon/daemon_linux.go
+++ b/src/github.com/imc-trading/peekaboo/daemon/daemon_linux.go
@@ -17,13 +17,14 @@ import (
 	"github.com/imc-trading/peekaboo/network/interfaces"
 	"github.com/imc-trading/peekaboo/network/routes"
 	"github.com/imc-trading/peekaboo/storage/disks"
+	"github.com/imc-trading/peekaboo/storage/filesystems"
 	"github.com/imc-trading/peekaboo/storage/lvm/logvols"
 	"github.com/imc-trading/peekaboo/storage/lvm/physvols"
 	"github.com/imc-trading/peekaboo/storage/lvm/volgrps"
-	"github.com/imc-trading/peekaboo/storage/filesystems"
 	"github.com/imc-trading/peekaboo/storage/mounts"
 	"github.com/imc-trading/peekaboo/system"
 	"github.com/imc-trading/peekaboo/system/cpu"
+	"github.com/imc-trading/peekaboo/system/cpu/load"
 	"github.com/imc-trading/peekaboo/system/ipmi"
 	"github.com/imc-trading/peekaboo/system/ipmi/sensors"
 	"github.com/imc-trading/peekaboo/system/kernel/config"
@@ -43,6 +44,7 @@ func New() Daemon {
 			apiURL + "/system/os":             {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/system/kernel/config":  {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/system/cpu":            {Timeout: 5 * 60},  // 5 min.
+			apiURL + "/system/cpu/load":       {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/system/memory":         {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/system/sysctls":        {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/system/ipmi":           {Timeout: 5 * 60},  // 5 min.
@@ -58,7 +60,7 @@ func New() Daemon {
 			apiURL + "/storage/lvm/physvols":  {Timeout: 15 * 60}, // 15 min.
 			apiURL + "/storage/lvm/logvols":   {Timeout: 15 * 60}, // 15 min.
 			apiURL + "/storage/lvm/volgrps":   {Timeout: 15 * 60}, // 15 min.
-			apiURL + "/storage/filesystems":   {Timeout: 5 * 60}, // 5 min.
+			apiURL + "/storage/filesystems":   {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/docker":                {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/docker/containers":     {Timeout: 5 * 60},  // 5 min.
 			apiURL + "/docker/images":         {Timeout: 5 * 60},  // 5 min.
@@ -76,6 +78,7 @@ func (d *daemon) Run(bind string, static string) error {
 	d.addAPIRoute(apiURL+"/system/os", opsys.GetInterface)
 	d.addAPIRoute(apiURL+"/system/kernel/config", config.GetInterface)
 	d.addAPIRoute(apiURL+"/system/cpu", cpu.GetInterface)
+	d.addAPIRoute(apiURL+"/system/cpu/load", load.GetInterface)
 	d.addAPIRoute(apiURL+"/system/memory", memory.GetInterface)
 	d.addAPIRoute(apiURL+"/system/sysctls", sysctls.GetInterface)
 	d.addAPIRoute(apiURL+"/system/ipmi", ipmi.GetInterface)

--- a/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_darwin.go
+++ b/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_darwin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/imc-trading/peekaboo/network/routes"
 	"github.com/imc-trading/peekaboo/system"
 	"github.com/imc-trading/peekaboo/system/cpu"
+	"github.com/imc-trading/peekaboo/system/cpu/load"
 	"github.com/imc-trading/peekaboo/system/memory"
 	"github.com/imc-trading/peekaboo/system/opsys"
 	"github.com/mickep76/dquery"
@@ -21,6 +22,7 @@ var hwTypes = []string{
 	"network/routes (short: routes)",
 	"system (short: sys)",
 	"system/cpu (short: cpu)",
+	"system/cpu/load (short: load)",
 	"system/memory (short: mem)",
 	"system/os (short: os)",
 	"docker (short: dkr)",
@@ -43,6 +45,8 @@ func Get(hwType string, filter string) error {
 		r, err = opsys.Get()
 	case "cpu", "system/cpu":
 		r, err = cpu.Get()
+	case "load", "system/cpu/load":
+		r, err = load.Get()
 	case "mem", "system/memory":
 		r, err = memory.Get()
 	case "dkr", "docker":

--- a/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_darwin.go
+++ b/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_darwin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/imc-trading/peekaboo/system/cpu"
 	"github.com/imc-trading/peekaboo/system/memory"
 	"github.com/imc-trading/peekaboo/system/opsys"
+	"github.com/mickep76/dquery"
 )
 
 var hwTypes = []string{
@@ -27,7 +28,7 @@ var hwTypes = []string{
 	"docker/images (short: imgs)",
 }
 
-func Get(hwType string) error {
+func Get(hwType string, filter string) error {
 	var r interface{}
 	var err error
 
@@ -59,7 +60,11 @@ func Get(hwType string) error {
 	}
 
 	b, _ := json.MarshalIndent(r, "", "  ")
-	fmt.Println(string(b))
+	j, err := dquery.FilterJSON(filter, b)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(j))
 
 	return nil
 }

--- a/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_linux.go
+++ b/src/github.com/imc-trading/peekaboo/hwtypes/hwtypes_linux.go
@@ -13,13 +13,14 @@ import (
 	"github.com/imc-trading/peekaboo/network/interfaces"
 	"github.com/imc-trading/peekaboo/network/routes"
 	"github.com/imc-trading/peekaboo/storage/disks"
+	"github.com/imc-trading/peekaboo/storage/filesystems"
 	"github.com/imc-trading/peekaboo/storage/lvm/logvols"
 	"github.com/imc-trading/peekaboo/storage/lvm/physvols"
 	"github.com/imc-trading/peekaboo/storage/lvm/volgrps"
 	"github.com/imc-trading/peekaboo/storage/mounts"
-	"github.com/imc-trading/peekaboo/storage/filesystems"
 	"github.com/imc-trading/peekaboo/system"
 	"github.com/imc-trading/peekaboo/system/cpu"
+	"github.com/imc-trading/peekaboo/system/cpu/load"
 	"github.com/imc-trading/peekaboo/system/ipmi"
 	"github.com/imc-trading/peekaboo/system/ipmi/sensors"
 	"github.com/imc-trading/peekaboo/system/kernel/config"
@@ -37,6 +38,7 @@ var hwTypes = []string{
 	"network/routes (short: routes)",
 	"system (short: sys)",
 	"system/cpu (short: cpu)",
+	"system/cpu/load (short: load)",
 	"system/memory (short: mem)",
 	"system/os (short: os)",
 	"system/kernelcfg (short: kcfg)",
@@ -76,6 +78,8 @@ func Get(hwType string, filter string) error {
 		r, err = config.Get()
 	case "cpu", "system/cpu":
 		r, err = cpu.Get()
+	case "load", "system/cpu/load":
+		r, err = load.Get()
 	case "sysctls", "system/sysctls":
 		r, err = sysctls.Get()
 	case "mem", "system/memory":
@@ -100,8 +104,8 @@ func Get(hwType string, filter string) error {
 		r, err = logvols.Get()
 	case "vgs", "storage/lvm/volgrps":
 		r, err = volgrps.Get()
-        case "fs", "storage/filesystems":
-                r, err = filesystems.Get()
+	case "fs", "storage/filesystems":
+		r, err = filesystems.Get()
 	case "dkr", "docker":
 		r, err = docker.Get()
 	case "cnts", "docker/containers":

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load.go
@@ -1,0 +1,15 @@
+package load
+
+// Load structure.
+type Load struct {
+	Avg1    float32 `json:"loadAvg1"`
+	Avg5    float32 `json:"loadAvg5"`
+	Avg10   float32 `json:"loadAvg10"`
+	Running int     `json:"processesRunning"`
+	Total   int     `json:"processesTotal"`
+	LastPid int     `json:"processesLastPid"`
+}
+
+func GetInterface() (interface{}, error) {
+	return Get()
+}

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load.go
@@ -4,7 +4,7 @@ package load
 type Load struct {
 	Avg1    float32 `json:"loadAvg1"`
 	Avg5    float32 `json:"loadAvg5"`
-	Avg10   float32 `json:"loadAvg10"`
+	Avg15   float32 `json:"loadAvg15"`
 	Running int     `json:"processesRunning"`
 	Total   int     `json:"processesTotal"`
 	LastPid int     `json:"processesLastPid"`

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load_darwin.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load_darwin.go
@@ -1,0 +1,37 @@
+// +build darwin
+
+package load
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func Get() (Load, error) {
+	l := Load{}
+	out, err := exec.Command("uptime").Output()
+	if err != nil {
+		return Load{}, err
+	}
+
+	outString := strings.Trim(string(out), "\n")
+	loadPrefix := "load averages: "
+	loadIndex := strings.Index(outString, loadPrefix)
+	loadAveragesString := outString[loadIndex+len(loadPrefix):]
+	tokens := strings.Split(loadAveragesString, " ")
+
+	avg1, _ := strconv.ParseFloat(tokens[0], 32)
+	avg5, _ := strconv.ParseFloat(tokens[1], 32)
+	avg10, _ := strconv.ParseFloat(tokens[2], 32)
+	l.Avg1 = float32(avg1)
+	l.Avg5 = float32(avg5)
+	l.Avg10 = float32(avg10)
+
+	// These values are not available in darwin
+	l.Running = -1
+	l.Total = -1
+	l.LastPid = -1
+
+	return l, nil
+}

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load_darwin.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load_darwin.go
@@ -26,7 +26,7 @@ func Get() (Load, error) {
 	avg10, _ := strconv.ParseFloat(tokens[2], 32)
 	l.Avg1 = float32(avg1)
 	l.Avg5 = float32(avg5)
-	l.Avg10 = float32(avg10)
+	l.Avg15 = float32(avg15)
 
 	// These values are not available in darwin
 	l.Running = -1

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load_linux.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load_linux.go
@@ -30,7 +30,7 @@ func Get() (Load, error) {
 	avg10, _ := strconv.ParseFloat(tokens[2], 32)
 	l.Avg1 = float32(avg1)
 	l.Avg5 = float32(avg5)
-	l.Avg10 = float32(avg10)
+	l.Avg15 = float32(avg15)
 
 	procTokens := strings.Split(tokens[3], "/")
 	l.Running, _ = strconv.Atoi(procTokens[0])

--- a/src/github.com/imc-trading/peekaboo/system/cpu/load/load_linux.go
+++ b/src/github.com/imc-trading/peekaboo/system/cpu/load/load_linux.go
@@ -1,0 +1,42 @@
+// +build linux
+
+package load
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func Get() (Load, error) {
+	l := Load{}
+	loadFileName := "/proc/loadavg"
+
+	if _, err := os.Stat(loadFileName); os.IsNotExist(err) {
+		return Load{}, errors.New("file doesn't exist: " + loadFileName)
+	}
+
+	loadString, err := ioutil.ReadFile(loadFileName)
+	if err != nil {
+		return Load{}, err
+	}
+
+	tokens := strings.Split(strings.TrimRight(string(loadString), "\n"), " ")
+
+	avg1, _ := strconv.ParseFloat(tokens[0], 32)
+	avg5, _ := strconv.ParseFloat(tokens[1], 32)
+	avg10, _ := strconv.ParseFloat(tokens[2], 32)
+	l.Avg1 = float32(avg1)
+	l.Avg5 = float32(avg5)
+	l.Avg10 = float32(avg10)
+
+	procTokens := strings.Split(tokens[3], "/")
+	l.Running, _ = strconv.Atoi(procTokens[0])
+	l.Total, _ = strconv.Atoi(procTokens[1])
+
+	l.LastPid, _ = strconv.Atoi(tokens[4])
+
+	return l, nil
+}


### PR DESCRIPTION
This PR provides information about cpu load on Linux and Darwin OSes.

The data model is based on Linux ```/proc/loadavg```. This is the file that is parsed to retrieve the information about the cpu load. The Darwin implementation simply uses ```uptime```, since there is no ```/proc``` filesystem equivalent. For this reason, some data on Darwin is not available (specifically: number of currently running processes, total number of running processes, pid of the last active process).

This PR also include a small fix in ```hwtypes_darwin.go``` to make ```./build``` succeed on Darwin.
