### PR TITLE
Branch: ExecRegexpMap-bugfix

### DIFF
--- a/src/github.com/imc-trading/peekaboo/parse/parse.go
+++ b/src/github.com/imc-trading/peekaboo/parse/parse.go
@@ -52,6 +52,8 @@ func ExecRegexpMap(cmd string, args []string, delim string, match string) (map[s
 		v := reDelim.Split(l, -1)
 		if len(v) < 1 {
 			continue
+		} else if len (v) > 1 {
+			v[1] = strings.TrimSpace(strings.Join(v[1:], delim))
 		}
 
 		m[strings.TrimSpace(v[0])] = strings.TrimSpace(v[1])


### PR DESCRIPTION
ExecRegexpMap will not properly parse k,v pairs that have the delim present in the values. E.g., pciBus will never get populated properly in /api/network/interfaces.

e.g.,

```
$ ethtool -i <intf>
driver: sfc
version: 4.13.1.1034
firmware-version: 6.2.7.1000 rx0 tx0
expansion-rom-version:
bus-info: 0000:02:00.1   <---- this line
supports-statistics: yes
supports-test: yes
supports-eeprom-access: no
supports-register-dump: yes
supports-priv-flags: yes
```

instead of returning map[bus-info:0000:02:00.1] you get map[bus-info:0000].

It would seem like this would result in the pciBus always being "0000", but at line 100 of interfaces.go, there is a check to see if pciBus starts with "0000:" before populating it (not sure why exactly).

```
100                                 if strings.HasPrefix(m["bus-info"], "0000:") {
101                                         s4 := m["bus-info"]
102                                         wIntf.PCIBus = &s4
103                                         s5 := fmt.Sprintf("/pci/%v", m["bus-info"])
104                                         wIntf.PCIBusURL = &s5
```

This caused pciBus to never be populated for any host.

My first time touching Go, so not sure if there is a better way to accomplish this.
